### PR TITLE
Fix character corruption.

### DIFF
--- a/src/Scripts/Install-Dev-Certificate.ps1
+++ b/src/Scripts/Install-Dev-Certificate.ps1
@@ -10,6 +10,6 @@ $certificate = "Chem4WordAddIn.pfx"
 
 Write-Host "Importing Certificate " $certificate
 
-$password = ConvertTo-SecureString -String "Password_123" -Force –AsPlainText
+$password = ConvertTo-SecureString -String "Password_123" -Force -AsPlainText
 
 Import-PfxCertificate -FilePath $certificate -CertStoreLocation Cert:\CurrentUser\My -Exportable -Password $password


### PR DESCRIPTION
Character corruption in the following line is fixed.
https://github.com/Chem4Word/Version3-1/blob/402143512f8b19a4cffc94fdce632cfa5776941b/src/Scripts/Install-Dev-Certificate.ps1#L13